### PR TITLE
修改 .json 輸出格式，避免json decoder failure

### DIFF
--- a/PttWebCrawler/crawler.py
+++ b/PttWebCrawler/crawler.py
@@ -70,7 +70,7 @@ class PttWebCrawler(object):
                         if div == divs[-1] and i == end-start:  # last div of last page
                             self.store(filename, self.parse(link, article_id, board), 'a')
                         else:
-                            self.store(filename, self.parse(link, article_id, board) + ',', 'a')
+                            self.store(filename, self.parse(link, article_id, board) + ',\n', 'a')
                     except:
                         pass
                 time.sleep(0.1)


### PR DESCRIPTION
嗨 J 大您好，我使用此套件時大多數時候運作良好，

但在爬取量稍大的時候（以 python -m PttWebCrawler -b Baseball -i 4530 5030 為例），

存成 .json 之後我打算在另一個 python 檔中用 json.loads( // .json string ) 讀取時會出現：

    Expecting value: line 1 column 1 (char xxxxxxxx)

的 JSON decoding error。

後來經過測試，其實只要把 JSON 存取格式微調(每個 record 加上一個換行)，

用 json.loads 讀取時就不會出問題了。

希望能夠提供改進，也謝謝 J 大開發這套爬蟲！