### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(
     name = 'PttWebCrawler',


### PR DESCRIPTION
FIX the setup.py raising warning when run it with Python3.4

Step to reproduce:
1. using Python3.4
2. run python setup.py install
3. will see warning like **unknown distribution option 'install_requires'**