### PR TITLE
better negative page index support

### DIFF
--- a/PttWebCrawler/crawler.py
+++ b/PttWebCrawler/crawler.py
@@ -41,11 +41,9 @@ class PttWebCrawler(object):
         board = args.b
         PTT_URL = 'https://www.ptt.cc'
         if args.i:
-            start = args.i[0]
-            if args.i[1] == -1:
-                end = self.getLastPage(board)
-            else:
-                end = args.i[1]
+            last = self.getLastPage(board)
+            indexs = [i if i>=0 else last+i+1 for i in args.i]
+            start, end = sorted(indexs)
             index = start
             filename = board + '-' + str(start) + '-' + str(end) + '.json'
             self.store(filename, u'{"articles": [', 'w')

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
     }
 
 ### 執行方式
-    python crawler.py -b 看板名稱 -i 起始索引 結束索引 (設為 -1 則自動計算最後一頁) 
+    python crawler.py -b 看板名稱 -i 起始索引 結束索引 (設為負數則以倒數第幾頁計算) 
     python crawler.py -b 看板名稱 -a 文章ID 
 
 ### 範例


### PR DESCRIPTION
- `python crawler -b BOARD_NAME -i -1 -10`
  - 可以爬倒數第一頁至倒數第十頁

現在可以 `python crawler -b BOARD_NAME -i 100 -1` 來爬100頁至最新一頁
不過也希望能夠有直接爬最新幾頁文章的功能，所以改了一下