### PR TITLE
Fix Deprecation Warning and Test Case Error in PTT Web CrawlerFix deprecation and test issues

### DIFF
--- a/PttWebCrawler/crawler.py
+++ b/PttWebCrawler/crawler.py
@@ -125,7 +125,7 @@ class PttWebCrawler(object):
             push.extract()
 
         try:
-            ip = main_content.find(text=re.compile(u'※ 發信站:'))
+            ip = main_content.find(string=re.compile(u'※ 發信站:'))
             ip = re.search('[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*', ip).group()
         except:
             ip = "None"

--- a/test.py
+++ b/test.py
@@ -39,9 +39,9 @@ class TestCrawler(unittest.TestCase):
         self.assertEqual(jsondata['board'], self.board)
 
     def test_parse_without_metalines(self):
-        self.link = 'https://www.ptt.cc/bbs/NBA/M.1432438578.A.4B0.html'
-        self.article_id = 'M.1432438578.A.4B0'
-        self.board = 'NBA'
+        self.link = 'https://www.ptt.cc/bbs/MacShop/M.1710908255.A.871.html'
+        self.article_id = 'M.1710908255.A.871'
+        self.board = 'MacShop'
 
         jsondata = json.loads(crawler.parse(self.link, self.article_id, self.board))
         self.assertEqual(jsondata['article_id'], self.article_id)


### PR DESCRIPTION
This pull request addresses two main issues in the PTT web crawler project:

1. **Deprecation Warning Fix**: Updated the `.find()` method argument from `text` to `string` in `crawler.py` to resolve the `DeprecationWarning` issued by BeautifulSoup. This change ensures compatibility with future versions of BeautifulSoup and eliminates the warning that was appearing during the execution.

2. **Test Case Fix**: Modified the `test_parse_without_metalines` method in `test.py` to use a valid PTT article URL, ID, and board name. The previous URL was causing a `404 Not Found` error leading to a `KeyError` during testing. This update ensures that the test accurately reflects the intended functionality and passes without errors.

By merging this pull request, the PTT web crawler will maintain up-to-date code standards and improve its test suite reliability.
